### PR TITLE
Update tenant user activation logic and default IsActive state

### DIFF
--- a/apps/Server/SmartRetail360.Domain/Entities/TenantUser.cs
+++ b/apps/Server/SmartRetail360.Domain/Entities/TenantUser.cs
@@ -11,7 +11,7 @@ public class TenantUser : IHasCreatedAt, IHasUpdatedAt
     public Guid TenantId { get; set; }
     public Guid UserId { get; set; }
     public Guid RoleId { get; set; }
-    public bool IsActive { get; set; } = true;                 
+    public bool IsActive { get; set; } = false;                 
     public DateTime JoinedAt { get; set; } = DateTime.UtcNow; 
     public DateTime? DeactivatedAt { get; set; } = null;
     public Guid? DeactivatedBy { get; set; } = null;                  


### PR DESCRIPTION
<!-- Please fill out the checklist below and link relevant tasks/issues -->

### Bugfix: Ensure TenantUser is inactive by default

#### ✅ Completed the following fixes:

- [x] Set `IsActive = false` by default in `TenantUser` entity
- [x] Modified activation service to explicitly set `IsActive = true` after user activation

---

#### 🧩 Related Modules:
- User
- Tenant
- AccountRegistration

---

#### 📌 Resolve:
SR-5